### PR TITLE
Add minimal Weblet prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,70 @@
-# New Protocol
+# 🧪 Weblet — Minimal Semantic Protocol Toy
 
-This is the initial README for the New Protocol project.
+This is a **tiny, local-only experiment** exploring an alternative way for devices to talk to each other — not through URLs and web pages, but through **semantic queries**: asking by *meaning* instead of *location*.
 
-## Description
+> ⚠️ **Disclaimer:** This is a **playful prototype**, not a real internet replacement. There is no security, no mesh, no guarantees. It’s just a small step toward imagining different networking ideas.
 
-This project aims to implement a new protocol for efficient data handling and processing.
+---
 
-## Installation
+## ✨ What It Does
 
-Instructions for installing the project will go here.
+* Runs a simple TCP server and client on your machine.
+* Client sends a **JSON query** describing *what it wants* (e.g., a quote with a certain mood).
+* Server looks up the best match in a **tiny in-memory object store** and responds.
+* Uses newline-delimited JSON messages, not HTTP.
 
-## Usage
+That’s all — no DNS, no HTML, no browsers.
 
-Examples of how to use the project will go here.
+---
 
-## Contributing
+## 🚀 Quick Start
 
-Guidelines for contributing to the project will go here.
+### 1. Run the Server
 
-## License
+```bash
+python weblet.py server 127.0.0.1 8088
+```
 
-Information about the project's license will go here.
+### 2. Run the Client
+
+```bash
+python weblet.py client 127.0.0.1 8088 '{"type":"quote","mood":"motivational"}'
+```
+
+You should see a **HELLO** message from the server, followed by a matching object.
+
+---
+
+## 🧠 Why This Exists
+
+The goal is **not** to replace the web, but to experiment with:
+
+* Semantic addressing (querying by intent)
+* Stateful message flows without HTTP
+* Thinking from first principles
+
+This is a stepping stone for bigger ideas — like building richer local networks — but this repo keeps it deliberately minimal and understandable.
+
+---
+
+## 📝 Next Steps (Optional)
+
+If you want to tinker:
+
+* Add more objects to the store.
+* Change the query resolution logic.
+* Extend the message types (e.g., add `STATE` or negotiation).
+
+---
+
+## ⚠️ Limitations
+
+* Not secure. Don’t expose it to the public internet.
+* Single server, single client. No mesh, no discovery.
+* Designed for clarity, not performance.
+
+---
+
+## 📄 License
+
+MIT — free to use, modify, and share, but **no warranty**.

--- a/weblet.py
+++ b/weblet.py
@@ -1,0 +1,132 @@
+# Bare-minimum demo of a "new internet protocol" idea:
+# - JSON messages over TCP (newline-delimited)
+# - Client sends a semantic QUERY (ask by meaning, not by URL)
+# - Server resolves from a tiny in-memory "object store" and replies
+#
+# Usage:
+#   python weblet.py server 127.0.0.1 8088
+#   python weblet.py client 127.0.0.1 8088 '{"type":"quote","mood":"motivational"}'
+#
+# Notes:
+# - Local-only toy. No security. Just for play.
+
+import sys
+import json
+import socket
+import threading
+
+HELLO = {"v": 0, "kind": "HELLO", "id": "srv", "negotiate": {"offer": ["object/json", "object/text"]}}
+
+# Tiny "semantic object store"
+STORE = [
+    {"id": "q1", "type": "quote", "mood": "motivational", "text": "Stay curious. Build boldly."},
+    {"id": "q2", "type": "quote", "mood": "calm", "text": "Slow is smooth, smooth is fast."},
+    {"id": "w1", "type": "weather", "location": "Vadodara", "time": "now", "temp_c": 33.5},
+]
+
+
+def resolve(intent):
+    """Naively resolve a query intent against the in-memory store."""
+    for obj in STORE:
+        if all(obj.get(k) == v for k, v in intent.items()):
+            return obj
+    return None
+
+
+def handle_client(conn, addr):
+    """Handle a single client connection."""
+    conn.sendall((json.dumps(HELLO) + "\n").encode())
+    buf = b""
+    try:
+        while True:
+            data = conn.recv(4096)
+            if not data:
+                break
+            buf += data
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                try:
+                    msg = json.loads(line.decode())
+                except Exception as exc:  # pylint: disable=broad-except
+                    err = {"v": 0, "kind": "ERROR", "id": "srv", "error": f"bad json: {exc}"}
+                    conn.sendall((json.dumps(err) + "\n").encode())
+                    continue
+
+                if msg.get("kind") == "QUERY":
+                    intent = msg.get("intent", {})
+                    obj = resolve(intent)
+                    if obj:
+                        rep = (msg.get("negotiate") or {}).get("pref", "object/json")
+                        if rep == "object/text":
+                            out = {
+                                "v": 0,
+                                "kind": "RESULT",
+                                "id": msg.get("id"),
+                                "object": {"text": obj.get("text", str(obj))},
+                            }
+                        else:
+                            out = {"v": 0, "kind": "RESULT", "id": msg.get("id"), "object": obj}
+                    else:
+                        out = {"v": 0, "kind": "ERROR", "id": msg.get("id"), "error": "no-match"}
+                    conn.sendall((json.dumps(out) + "\n").encode())
+    finally:
+        conn.close()
+
+
+def server(host, port):
+    """Run the toy server."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind((host, int(port)))
+    sock.listen(5)
+    print(f"[server] listening on {host}:{port}")
+    try:
+        while True:
+            conn, addr = sock.accept()
+            threading.Thread(target=handle_client, args=(conn, addr), daemon=True).start()
+    finally:
+        sock.close()
+
+
+def client(host, port, query_json, pref="object/json"):
+    """Run the toy client."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((host, int(port)))
+    file = sock.makefile("rwb", buffering=0)
+
+    line = file.readline()
+    if line:
+        print(line.decode().strip())
+
+    msg = {
+        "v": 0,
+        "kind": "QUERY",
+        "id": "cli-1",
+        "intent": json.loads(query_json),
+        "negotiate": {"pref": pref},
+    }
+    file.write((json.dumps(msg) + "\n").encode())
+    resp = file.readline()
+    if resp:
+        print(resp.decode().strip())
+    sock.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        print(
+            "Usage:\n  python weblet.py server <host> <port>\n  python weblet.py client <host> <port> '<query_json>'"
+        )
+        sys.exit(1)
+
+    mode = sys.argv[1]
+    if mode == "server":
+        server(sys.argv[2], sys.argv[3])
+    elif mode == "client":
+        if len(sys.argv) < 5:
+            print("client needs a JSON query, e.g. '{\"type\":\"quote\",\"mood\":\"motivational\"}'")
+            sys.exit(1)
+        client(sys.argv[2], sys.argv[3], sys.argv[4])
+    else:
+        print("mode must be 'server' or 'client'")


### PR DESCRIPTION
## Summary
- add a tiny Python prototype that demonstrates semantic query client/server messaging
- rewrite the README to document the local-only experiment and how to run it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbaef2d808327aca6d771ab984510